### PR TITLE
The logic for calling the child script `experiments/create-dir-script` was wrong.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -55,22 +55,30 @@ function _prefix {
 SUBDIRS=$(_prefix "$ROOTDIR" obj)
 SUBDIRS="$SUBDIRS $(_prefix "$ROOTDIR/experiments" AlgorithmTesting BBS CCG G-SHA1 LCG MODEXP MS QCG1 QCG2 XOR)"
 
+echo "Setting up directories in $ROOTDIR/experiments."
 for i in $SUBDIRS ; do
 	if [ ! -d "$i" ]; then
 		mkdir -p "$i" || _error "Can't create dir: $i"
+        echo "Created $i."
+    else
+        echo "$i already exists."
 	fi
 done
 
-# now we create the subdirectories
-	(
-	cd $ROOTDIR/experiments || _error "Can't cd: $ROOTDIR/experiments"
-	if [ ! -d AlgorithmTesting ]; then
-		./create-dir-script
-		if [ $? -ne 0 ]; then
-			echo "$PNAME: some diretory creations failed; this probably isn't a problem, but please check!"
-		fi
-	fi
-	) || exit $?
+echo "Creating the subdirectories via child script."
+(
+cd $ROOTDIR/experiments || _error "Can't cd: $ROOTDIR/experiments"
+if [ -d AlgorithmTesting ]; then
+    ./create-dir-script
+    if [ $? -ne 0 ]; then
+        echo "$PNAME: some diretory creations failed; this probably isn't a problem, but please check!"
+    else
+        echo "Child script succeeded."
+    fi
+else
+    echo "Skipping child script. An earlier step failed?"
+fi
+) || exit $?
 
 echo "Directories are set up. Change directory to $ROOTDIR and say 'make'!"
 


### PR DESCRIPTION
The operative change is on (old) line 67: removing the `!`.